### PR TITLE
feat: Add set_custom_time service

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,47 @@ actions:
       node_id: 7
       endpoint: 0
 mode: restart
+```
+
+---
+
+### Service: `matter_time_sync.set_custom_time`
+
+Set a custom date and time on a Matter device. This is useful for creating stopwatch-like functionality, testing time-based features, or temporarily displaying a different time.
+
+**Parameters:**
+*   `node_id` (Required): The Matter Node ID of the device (integer).
+*   `endpoint` (Optional): The endpoint ID (default: `0`).
+*   `date` (Required): The date to set (format: `YYYY-MM-DD`).
+*   `time` (Required): The time to set (format: `HH:MM:SS`).
+
+### Example: Cooking Timer (YAML)
+
+Resets the device time to zero when you start cooking, so it displays how long the food has been in the oven. When turned off, it syncs back to the current time:
+
+```yaml
+alias: "[TIME] Cooking Timer"
+description: >-
+  Resets the IKEA ALPSTUGA time to epoch when the oven is turned on,
+  displaying elapsed cooking time. Reverts to current time when turned off.
+triggers:
+  - entity_id: switch.oven_power
+    trigger: state
+actions:
+  - if:
+      - condition: state
+        entity_id: switch.oven_power
+        state: "on"
+    then:
+      - action: matter_time_sync.set_custom_time
+        data:
+          node_id: 7
+          endpoint: 0
+          date: "2000-01-01"
+          time: "00:00:00"
+    else:
+      - action: matter_time_sync.sync_time
+        data:
+          node_id: 7
+          endpoint: 0
+mode: single

--- a/custom_components/matter_time_sync/services.yaml
+++ b/custom_components/matter_time_sync/services.yaml
@@ -23,3 +23,43 @@ sync_time:
           min: 0
           max: 255
           mode: box
+
+set_custom_time:
+  name: Set custom time
+  description: Set a custom date and time on a Matter device.
+  fields:
+    node_id:
+      name: Node ID
+      description: Matter device node ID
+      required: true
+      example: 7
+      selector:
+        number:
+          min: 1
+          max: 65535
+          mode: box
+    endpoint:
+      name: Endpoint
+      description: Matter device endpoint ID
+      required: false
+      default: 0
+      example: 0
+      selector:
+        number:
+          min: 0
+          max: 255
+          mode: box
+    date:
+      name: Date
+      description: The date to set on the device (YYYY-MM-DD)
+      required: true
+      example: "2000-01-01"
+      selector:
+        date:
+    time:
+      name: Time
+      description: The time to set on the device (HH:MM:SS)
+      required: true
+      example: "00:00:00"
+      selector:
+        time:


### PR DESCRIPTION
## Summary

Adds a new `set_custom_time` service that allows users to manually set a specific date and time on Matter devices, complementing the existing `sync_time` service.

## New Service: `matter_time_sync.set_custom_time`

**Parameters:**
- `node_id` (required): Matter device node ID
- `endpoint` (optional): Endpoint ID (default: 0)
- `date` (required): Date in YYYY-MM-DD format
- `time` (required): Time in HH:MM:SS format

## Use Cases

- Creating stopwatch functionality (e.g., cooking timers, activity tracking)
- Testing time-based device features
- Temporarily displaying a custom time on a device

## Changes

- Added `set_custom_time` service in `__init__.py`
- Added service schema and handler
- Added `run_sync_custom_time` method to `MatterTimeSyncAsync` class
- Updated `services.yaml` with new service definition
- Updated `README.md` with documentation and example automation