### PR TITLE
Fix DST handling (avoid double-counting DST in SetTimeZone)

### DIFF
--- a/custom_components/matter_time_sync/coordinator.py
+++ b/custom_components/matter_time_sync/coordinator.py
@@ -267,13 +267,14 @@ class MatterTimeSyncCoordinator:
         now = datetime.now(tz)
         utc_now = datetime.now(ZoneInfo("UTC"))
 
-        # UTC offset in seconds (e.g., 3600 for UTC+1)
-        utc_offset = int(now.utcoffset().total_seconds())
+        # Total UTC offset in seconds (includes DST when applicable)
+        total_offset = int(now.utcoffset().total_seconds()) if now.utcoffset() else 0
 
-        # Check for DST offset
-        dst_offset = 0
-        if now.dst() is not None:
-            dst_offset = int(now.dst().total_seconds())
+        # DST offset in seconds (0 when not in DST)
+        dst_offset = int(now.dst().total_seconds()) if now.dst() else 0
+
+        # Base timezone offset (excluding DST) to avoid double-counting DST
+        utc_offset = total_offset - dst_offset
 
         # UTC time in microseconds since epoch
         utc_microseconds = int(utc_now.timestamp() * 1_000_000)


### PR DESCRIPTION
## What
Fixes DST being applied twice by computing a **base** timezone offset (standard offset) separately from the DST offset.

## Why
`datetime.utcoffset()` already includes DST when it is active. The previous implementation sent that full offset to `SetTimeZone` and also sent `dst()` via `SetDSTOffset`, which can cause devices to add DST twice (e.g., Australia during AEDT).

## Changes
- Compute `total_offset = utcoffset()`
- Compute `dst_offset = dst()`
- Send `utc_offset = total_offset - dst_offset` to `SetTimeZone`
- Keep `dst_offset` for `SetDSTOffset`

## Testing
- Manual: verify logs show base offset and DST separately and that local device time matches expected during DST regions (e.g., Australia).
