### PR TITLE
Set time sync button entity category to CONFIG

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Matter Time Sync for Home Assistant
 
-![Version](https://img.shields.io/badge/version-2.2.1-blue)
+![Version](https://img.shields.io/badge/version-2.2.2-blue)
 ![Home Assistant](https://img.shields.io/badge/Home%20Assistant-Custom%20Component-orange)
 
 A native Home Assistant custom component to synchronize **Time** and **Timezone** on Matter devices that support the Time Synchronization cluster.
@@ -242,6 +242,10 @@ logger:
 ---
 
 ## 📋 Version History
+
+### v2.2.2
+🐛 Bug Fixes
+- Fixed crash when device registry identifiers are not 2-tuples.
 
 ### v2.2.1
 ✨ New Features

--- a/custom_components/matter_time_sync/button.py
+++ b/custom_components/matter_time_sync/button.py
@@ -22,6 +22,7 @@ from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -278,6 +279,7 @@ class MatterTimeSyncButton(ButtonEntity):
 
     _attr_icon = "mdi:clock-check-outline"
     _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.CONFIG
     _attr_translation_key = "sync_time"
 
     _PRESS_COOLDOWN_SECONDS = 2.0

--- a/custom_components/matter_time_sync/button.py
+++ b/custom_components/matter_time_sync/button.py
@@ -51,7 +51,12 @@ def _matter_device_identifiers_for_node(
     needle = f"-{node_id:016X}-MatterNodeDevice"
 
     for dev in device_reg.devices.values():
-        for domain, ident in dev.identifiers:
+        for identifier in dev.identifiers:
+            if len(identifier) < 2:
+                _LOGGER.debug("Skipping malformed identifier: %s", identifier)
+                continue
+            domain = identifier[0]
+            ident = identifier[1]
             if domain != "matter":
                 continue
             ident_str = str(ident)

--- a/custom_components/matter_time_sync/coordinator.py
+++ b/custom_components/matter_time_sync/coordinator.py
@@ -321,6 +321,9 @@ class MatterTimeSyncCoordinator:
             node_id_str = str(node_id)
             for device in device_reg.devices.values():
                 for identifier in device.identifiers:
+                    if len(identifier) < 2:
+                        _LOGGER.debug("Skipping malformed identifier: %s", identifier)
+                        continue
                     if identifier[0] != "matter":
                         continue
 

--- a/custom_components/matter_time_sync/manifest.json
+++ b/custom_components/matter_time_sync/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/Loweack/Matter-Time-Sync/issues",
   "requirements": ["aiohttp"],
-  "version": "2.2.1"
+  "version": "2.2.2"
 }


### PR DESCRIPTION
Hello,
First of all, thank you very much for this custom component.
Saves a lot of time, absolutely brilliant!

Just my small 5cents - I believe the `Sync Time` button should be under the `CONFIG` category:
- It does not control the device
- It changes the device configuration (time settings)